### PR TITLE
Add in Rpi Serial Passthrough

### DIFF
--- a/Raspberry Pi/rpi_setup.md
+++ b/Raspberry Pi/rpi_setup.md
@@ -1,0 +1,42 @@
+# Raspberry Pi Zero W Configuration
+
+This guide will walk you through how to setup your Raspberry Pi Zero W to have the necessary permissions, libraries, and code to be able to function with the Hexapod.
+
+## Flashing the SD Card
+
+1. [Get the Raspberry Pi Imaging Tool](https://www.raspberrypi.com/software/).
+2. Choose `Raspberry Pi Zero 2 W` for the `Raspberry Pi Device`.
+3. Choose `Raspberry Pi OS Lite` for the `Operating System`.
+4. Choose the appropriate MicroSD card for `Storage`.
+5. Click `Next`.
+6. Select `Edit Settings` for `Would you like to apply OS customisation settings`.
+7. Set `hostname` to be `hexapod<lastname>.local` -- this will prevent issue if multiple Hexapods are in the same area/network.
+8. Set your `username` and `password` as appropriate.
+9. Configure `Wireless LAN` and `Set Locale Settings` as necessary.
+10. Navigate to `Services`.
+11. Check `Enable SSH` and `Use password authentication`.
+12. `Save` and flash the SD card!
+
+## Configuring the Raspberry Pi
+
+1. SSH into the Raspberry Pi using the information above. `SSH <username>@hexapod<lastname>.local`.
+2. Enter `sudo raspi-config` in terminal.
+3. Select `Interface Options` then select `I6 Serial Port`.
+4. `Would you like a login shell to be accessible over serial?` --> `No`.
+5. `Would you like the serial port hardware to be enabled?` --> `Yes`.
+6. Exit out.
+7. Run `sudo reboot` and log back in.
+
+## Installing Libraries
+
+1. Run `sudo apt-get update`
+2. Run `sudo apt-get install python3-serial`
+
+## Example Files
+
+### Testing Serial
+
+- [testing_serial.py](Raspberry\%Pi/rpi_setup.md) & [testing_serial.ino](Raspberry\%Pi/testing_serial.ino)
+  - Used to ensure your Raspberry Pi is configured properly and that the Raspberry pi can take command via SSH and pass them via serial to the Teensy 4.1.
+  - Usage: `python3 raspi_serial.py "Hello World"`
+  - If you aren't able to run the file, make sure it is an executable by doing: `chmod +x raspi_serial.py`

--- a/Raspberry Pi/testing_serial.ino
+++ b/Raspberry Pi/testing_serial.ino
@@ -1,0 +1,32 @@
+const int bufferSize = 64;
+char buffer[bufferSize];
+int bufferIndex = 0;
+
+void setup() {
+  Serial.begin(9600);
+  Serial4.begin(9600);
+}
+
+void loop() {
+  while (Serial4.available() > 0) {
+    char receivedChar = Serial4.read();
+
+    if (receivedChar == '\n') {
+      // End of word, process the complete word
+      buffer[bufferIndex] = '\0';  // Null-terminate the string
+      Serial.print("Received from Raspberry Pi: ");
+      Serial.println(buffer);
+
+      // Reset bufferIndex for the next word
+      bufferIndex = 0;
+    } else {
+      // Add the character to the buffer
+      if (bufferIndex < bufferSize - 1) {
+        buffer[bufferIndex++] = receivedChar;
+      } else {
+        // Buffer overflow, handle error or reset the buffer
+        bufferIndex = 0;
+      }
+    }
+  }
+}

--- a/Raspberry Pi/testing_serial.py
+++ b/Raspberry Pi/testing_serial.py
@@ -1,0 +1,26 @@
+import serial
+import sys
+
+# Define the serial connection
+ser = serial.Serial('/dev/ttyS0', 9600, timeout=1)
+
+def send_to_teensy(data):
+    # Append a newline character at the end of the data
+    ser.write((data + '\n').encode())
+
+# Read input from command line arguments
+if len(sys.argv) != 2:
+    print("Usage: python raspi_serial.py <data_to_send>")
+    sys.exit(1)
+
+data_to_send = sys.argv[1]
+
+try:
+    # Send data to Teensy with a newline character
+    send_to_teensy(data_to_send)
+    print(f"Sent to Teensy: {data_to_send}")
+except Exception as e:
+    print(f"Error: {e}")
+
+# Close the serial connection
+ser.close()


### PR DESCRIPTION
Add in Rpi Serial Passthrough for #21 . The .ino code should likely migrate it's way to HexapodController, but for now I figured it made more sense to group them as that .ino is standalone.

This is also very basic functionality, but ran into a lot of pitfalls so hopefully this speeds up future iterating