### PR TITLE
Update Mk2 Schematic

### DIFF
--- a/Mk2/Mk2_PCB/hexapod_mk2_v0.0.brd
+++ b/Mk2/Mk2_PCB/hexapod_mk2_v0.0.brd
@@ -2042,6 +2042,29 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <wire x1="1.3" y1="-2.3" x2="1.3" y2="-1.8" width="0.2" layer="21"/>
 <wire x1="-1.3" y1="-1.8" x2="1.3" y2="-1.8" width="0.2" layer="21"/>
 </package>
+<package name="JST-XH-04-PACKAGE-LONG-PAD">
+<description>&lt;b&gt;JST XH Connector Long Pads (Package)&lt;/b&gt;&lt;p&gt;
+Wire to board connector.
+
+Pitch: 2,54 mm, (0.100")&lt;p&gt;
+Number of pins: &lt;b&gt;4&lt;/b&gt;&lt;b&gt;&lt;P&gt;
+
+&lt;b&gt;Created by Rembrandt Electronics&lt;/b&gt;&lt;p&gt;
+&lt;b&gt;www.rembrandtelectronics.com&lt;/b&gt;&lt;p&gt;</description>
+<wire x1="6.2" y1="-2.3575" x2="6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="6.2" y1="3.3925" x2="-6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="3.3925" x2="-6.2" y2="-2.3575" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="-2.3575" x2="6.2" y2="-2.3575" width="0.254" layer="21"/>
+<pad name="3" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.655" y="-2.04" size="1.016" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="-6.0025" y="3.8925" size="1.016" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-5.4675" y="-1.4875" size="1.016" layer="51" ratio="10">1</text>
+<wire x1="-3.8" y1="-2.3" x2="-3.8" y2="-1.8" width="0.254" layer="21"/>
+<wire x1="3.9" y1="-2.3" x2="3.9" y2="-1.8" width="0.254" layer="21"/>
+</package>
 </packages>
 </library>
 </libraries>
@@ -2324,6 +2347,10 @@ design rules under a new name.</description>
 <attribute name="NAME" x="-20.755" y="-45.04" size="1.016" layer="25" ratio="10" rot="R90"/>
 <attribute name="VALUE" x="-19.8025" y="-39.1075" size="1.016" layer="27" ratio="10"/>
 </element>
+<element name="FAN" library="Rembrandt Electronics - JST XH Connectors v1-0" package="JST-XH-04-PACKAGE-LONG-PAD" value="JST-XH-04-PIN-LONG-PAD" x="-14" y="-51" smashed="yes">
+<attribute name="NAME" x="-20.655" y="-53.04" size="1.016" layer="25" ratio="10" rot="R90"/>
+<attribute name="VALUE" x="-20.0025" y="-47.1075" size="1.016" layer="27" ratio="10"/>
+</element>
 </elements>
 <signals>
 <signal name="5V">
@@ -2393,16 +2420,10 @@ design rules under a new name.</description>
 <via x="27" y="51.5" extent="1-16" drill="0.35"/>
 <via x="24.5" y="51.25" extent="1-16" drill="0.35"/>
 <via x="27.25" y="51.25" extent="1-16" drill="0.35"/>
-<contactref element="S1" pad="5"/>
-<contactref element="S1" pad="6"/>
-<contactref element="S1" pad="7"/>
-<contactref element="S1" pad="8"/>
 <contactref element="LED_RING" pad="P$1"/>
-<wire x1="-5.31" y1="-27.5042" x2="-12" y2="-33" width="0" layer="19" extent="1-1"/>
-<wire x1="-2.77" y1="-27.5042" x2="-5.31" y2="-27.5042" width="0" layer="19" extent="1-1"/>
-<wire x1="-0.23" y1="-27.5042" x2="-2.77" y2="-27.5042" width="0" layer="19" extent="1-1"/>
-<wire x1="2.31" y1="-27.5042" x2="-0.23" y2="-27.5042" width="0" layer="19" extent="1-1"/>
-<wire x1="19.46" y1="9.52" x2="2.31" y2="-27.5042" width="0" layer="19" extent="1-1"/>
+<contactref element="FAN" pad="3"/>
+<wire x1="-12" y1="-33" x2="-12.73" y2="-51" width="0" layer="19" extent="1-1"/>
+<wire x1="19.46" y1="9.52" x2="-12" y2="-33" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="GND">
 <contactref element="LEG0" pad="P$2"/>
@@ -2537,10 +2558,12 @@ design rules under a new name.</description>
 <via x="54.75" y="53.75" extent="1-16" drill="0.35"/>
 <via x="29.5" y="51.25" extent="1-16" drill="0.35"/>
 <via x="65.25" y="51.25" extent="1-16" drill="0.35"/>
-<contactref element="R1" pad="2"/>
 <contactref element="LED_RING" pad="P$2"/>
-<wire x1="7.0033" y1="-13.1176" x2="-14.5" y2="-33" width="0" layer="19" extent="1-1"/>
-<wire x1="2.77" y1="9.52" x2="7.0033" y2="-13.1176" width="0" layer="19" extent="1-1"/>
+<contactref element="R1" pad="1"/>
+<contactref element="FAN" pad="4"/>
+<wire x1="-14.5" y1="-33" x2="-10.19" y2="-51" width="0" layer="19" extent="1-1"/>
+<wire x1="4.9967" y1="-13.1176" x2="-14.5" y2="-33" width="0" layer="19" extent="1-1"/>
+<wire x1="2.77" y1="9.52" x2="4.9967" y2="-13.1176" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="L0M1">
 <contactref element="LEG0" pad="P$3"/>
@@ -2847,8 +2870,8 @@ design rules under a new name.</description>
 <wire x1="7" y1="12.25" x2="7" y2="29.5" width="0.1524" layer="1"/>
 <wire x1="13.25" y1="35.75" x2="13.41" y2="35.98" width="0.1524" layer="1"/>
 <wire x1="7" y1="12.25" x2="8.01" y2="12.08" width="0.1524" layer="1"/>
-<contactref element="R1" pad="1"/>
-<wire x1="4.9967" y1="-13.1176" x2="4.74" y2="12.13" width="0" layer="19" extent="1-1"/>
+<contactref element="R1" pad="2"/>
+<wire x1="7.0033" y1="-13.1176" x2="8.01" y2="12.08" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="12V_PRE">
 <contactref element="BATTERY" pad="+"/>
@@ -2908,7 +2931,15 @@ design rules under a new name.</description>
 <signal name="3.3V">
 <contactref element="RPI5" pad="1"/>
 <contactref element="X1" pad="1"/>
-<wire x1="-17.77" y1="-43" x2="24.5" y2="51.35" width="0" layer="19" extent="1-1"/>
+<contactref element="S1" pad="8"/>
+<contactref element="S1" pad="7"/>
+<contactref element="S1" pad="6"/>
+<contactref element="S1" pad="5"/>
+<wire x1="2.31" y1="-27.5042" x2="24.5" y2="51.35" width="0" layer="19" extent="1-1"/>
+<wire x1="-0.23" y1="-27.5042" x2="2.31" y2="-27.5042" width="0" layer="19" extent="1-1"/>
+<wire x1="-2.77" y1="-27.5042" x2="-0.23" y2="-27.5042" width="0" layer="19" extent="1-1"/>
+<wire x1="-5.31" y1="-27.5042" x2="-2.77" y2="-27.5042" width="0" layer="19" extent="1-1"/>
+<wire x1="-17.77" y1="-43" x2="-5.31" y2="-27.5042" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="PWRSIG">
 <contactref element="X1" pad="2"/>
@@ -2916,6 +2947,16 @@ design rules under a new name.</description>
 <contactref element="U$1" pad="0-RX1/CS1/CRX2"/>
 <wire x1="27.04" y1="51.35" x2="75.26" y2="31.5" width="0" layer="19" extent="1-1"/>
 <wire x1="-15.23" y1="-43" x2="27.04" y2="51.35" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="FAN_PWM">
+<contactref element="FAN" pad="1"/>
+<contactref element="RPI5" pad="32"/>
+<wire x1="-17.81" y1="-51" x2="62.6" y2="53.89" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="FAN_RPM">
+<contactref element="FAN" pad="2"/>
+<contactref element="RPI5" pad="38"/>
+<wire x1="-15.27" y1="-51" x2="70.22" y2="53.89" width="0" layer="19" extent="1-1"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/Mk2/Mk2_PCB/hexapod_mk2_v0.0.sch
+++ b/Mk2/Mk2_PCB/hexapod_mk2_v0.0.sch
@@ -8,34 +8,34 @@
 </settings>
 <grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
-<layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
-<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
-<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
-<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
-<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
-<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
-<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
-<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
-<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
-<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
-<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
-<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
-<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
-<layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
-<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
-<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
-<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
-<layer number="20" name="Dimension" color="24" fill="1" visible="no" active="no"/>
-<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
-<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="no"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="yes" active="no"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="yes" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="yes" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="yes" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="yes" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="yes" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="yes" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="yes" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="yes" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="yes" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="yes" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="yes" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="yes" active="no"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="yes" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="no"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="no"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
@@ -44,8 +44,8 @@
 <layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
 <layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
 <layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
-<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
-<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="no"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
 <layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="no"/>
@@ -53,19 +53,19 @@
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
-<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="no" active="no"/>
-<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
-<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
-<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
-<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="no" active="no"/>
-<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="no" active="no"/>
-<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
-<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
-<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="no"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="yes" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="no"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="yes" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="no"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="yes" active="no"/>
+<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="yes" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="yes" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="yes" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="yes" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="yes" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
@@ -8844,6 +8844,53 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <wire x1="1.3" y1="-2.3" x2="1.3" y2="-1.8" width="0.2" layer="21"/>
 <wire x1="-1.3" y1="-1.8" x2="1.3" y2="-1.8" width="0.2" layer="21"/>
 </package>
+<package name="JST-XH-04-PACKAGE-LONG-PAD">
+<description>&lt;b&gt;JST XH Connector Long Pads (Package)&lt;/b&gt;&lt;p&gt;
+Wire to board connector.
+
+Pitch: 2,54 mm, (0.100")&lt;p&gt;
+Number of pins: &lt;b&gt;4&lt;/b&gt;&lt;b&gt;&lt;P&gt;
+
+&lt;b&gt;Created by Rembrandt Electronics&lt;/b&gt;&lt;p&gt;
+&lt;b&gt;www.rembrandtelectronics.com&lt;/b&gt;&lt;p&gt;</description>
+<wire x1="6.2" y1="-2.3575" x2="6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="6.2" y1="3.3925" x2="-6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="3.3925" x2="-6.2" y2="-2.3575" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="-2.3575" x2="6.2" y2="-2.3575" width="0.254" layer="21"/>
+<pad name="3" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.655" y="-2.04" size="1.016" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="-6.0025" y="3.8925" size="1.016" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-5.4675" y="-1.4875" size="1.016" layer="51" ratio="10">1</text>
+<wire x1="-3.8" y1="-2.3" x2="-3.8" y2="-1.8" width="0.254" layer="21"/>
+<wire x1="3.9" y1="-2.3" x2="3.9" y2="-1.8" width="0.254" layer="21"/>
+</package>
+<package name="JST-XH-04-PACKAGE-ROUND-PAD">
+<description>&lt;b&gt;JST XH Connector Round Pads (Package)&lt;/b&gt;&lt;p&gt;
+
+Wire to board connector.
+
+Pitch: 2,54 mm, (0.100")&lt;p&gt;
+Number of pins: &lt;b&gt;4&lt;/b&gt;&lt;b&gt;&lt;P&gt;
+
+&lt;b&gt;Created by Rembrandt Electronics&lt;/b&gt;&lt;p&gt;
+&lt;b&gt;www.rembrandtelectronics.com&lt;/b&gt;&lt;p&gt;</description>
+<wire x1="6.2" y1="-2.3575" x2="6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="6.2" y1="3.3925" x2="-6.2" y2="3.3925" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="3.3925" x2="-6.2" y2="-2.3575" width="0.254" layer="21"/>
+<wire x1="-6.2" y1="-2.3575" x2="6.2" y2="-2.3575" width="0.254" layer="21"/>
+<pad name="3" x="1.27" y="0" drill="1.016" rot="R90"/>
+<pad name="2" x="-1.27" y="0" drill="1.016" rot="R90"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" rot="R90"/>
+<pad name="4" x="3.81" y="0" drill="1.016" rot="R90"/>
+<text x="-6.655" y="-2.04" size="1.016" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="-6.0025" y="3.8925" size="1.016" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-5.4675" y="-1.4875" size="1.016" layer="51" ratio="10">1</text>
+<wire x1="-3.8" y1="-2.3" x2="-3.8" y2="-1.8" width="0.254" layer="21"/>
+<wire x1="3.9" y1="-2.3" x2="3.9" y2="-1.8" width="0.254" layer="21"/>
+</package>
 </packages>
 <symbols>
 <symbol name="M">
@@ -8887,6 +8934,47 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <connects>
 <connect gate="-1" pin="S" pad="1"/>
 <connect gate="-2" pin="S" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="JST-XH-04-PIN" prefix="X">
+<description>&lt;b&gt;JST XH Connector 2 Pin&lt;/b&gt;&lt;p&gt;
+
+Wire to board connector.
+
+Pitch: 2,54 mm, (0.100")&lt;p&gt;
+Number of pins: &lt;b&gt;4&lt;/b&gt;&lt;b&gt;&lt;P&gt;
+
+&lt;b&gt;Created by Rembrandt Electronics&lt;/b&gt;&lt;p&gt;
+&lt;b&gt;www.rembrandtelectronics.com&lt;/b&gt;&lt;p&gt;</description>
+<gates>
+<gate name="-1" symbol="MV" x="2.54" y="0" addlevel="always" swaplevel="1"/>
+<gate name="-2" symbol="M" x="2.54" y="-2.54" addlevel="always" swaplevel="1"/>
+<gate name="-3" symbol="M" x="2.54" y="-5.08" addlevel="always" swaplevel="1"/>
+<gate name="-4" symbol="M" x="2.54" y="-7.62" addlevel="always" swaplevel="1"/>
+</gates>
+<devices>
+<device name="-LONG-PAD" package="JST-XH-04-PACKAGE-LONG-PAD">
+<connects>
+<connect gate="-1" pin="S" pad="1"/>
+<connect gate="-2" pin="S" pad="2"/>
+<connect gate="-3" pin="S" pad="3"/>
+<connect gate="-4" pin="S" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-ROUND-PAD" package="JST-XH-04-PACKAGE-ROUND-PAD">
+<connects>
+<connect gate="-1" pin="S" pad="1"/>
+<connect gate="-2" pin="S" pad="2"/>
+<connect gate="-3" pin="S" pad="3"/>
+<connect gate="-4" pin="S" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -8949,6 +9037,7 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <part name="S1" library="smd-special" library_urn="urn:adsk.eagle:library:362" deviceset="SWS004" device="" package3d_urn="urn:adsk.eagle:package:26474/1"/>
 <part name="LED_RING" library="bt_con-jst-xh" deviceset="03-JST" device="-B3B-XH-A"/>
 <part name="X1" library="Rembrandt Electronics - JST XH Connectors v1-0" deviceset="JST-XH-02-PIN" device="-LONG-PAD"/>
+<part name="FAN" library="Rembrandt Electronics - JST XH Connectors v1-0" deviceset="JST-XH-04-PIN" device="-LONG-PAD"/>
 </parts>
 <sheets>
 <sheet>
@@ -9130,6 +9219,19 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <attribute name="NAME" x="-27.94" y="-16.002" size="1.524" layer="95"/>
 <attribute name="VALUE" x="-31.242" y="-13.843" size="1.778" layer="96"/>
 </instance>
+<instance part="FAN" gate="-1" x="-30.48" y="-30.48" smashed="yes">
+<attribute name="NAME" x="-27.94" y="-31.242" size="1.524" layer="95"/>
+<attribute name="VALUE" x="-31.242" y="-29.083" size="1.778" layer="96"/>
+</instance>
+<instance part="FAN" gate="-2" x="-30.48" y="-33.02" smashed="yes">
+<attribute name="NAME" x="-27.94" y="-33.782" size="1.524" layer="95"/>
+</instance>
+<instance part="FAN" gate="-3" x="-30.48" y="-35.56" smashed="yes">
+<attribute name="NAME" x="-27.94" y="-36.322" size="1.524" layer="95"/>
+</instance>
+<instance part="FAN" gate="-4" x="-30.48" y="-38.1" smashed="yes">
+<attribute name="NAME" x="-27.94" y="-38.862" size="1.524" layer="95"/>
+</instance>
 </instances>
 <busses>
 </busses>
@@ -9191,27 +9293,14 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <label x="-15.24" y="63.5" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="S1" gate="G$1" pin="5"/>
-<wire x1="-20.32" y1="-2.54" x2="-17.78" y2="-2.54" width="0.1524" layer="91"/>
-<pinref part="S1" gate="G$1" pin="6"/>
-<wire x1="-17.78" y1="-2.54" x2="-17.78" y2="0" width="0.1524" layer="91"/>
-<wire x1="-17.78" y1="0" x2="-20.32" y2="0" width="0.1524" layer="91"/>
-<pinref part="S1" gate="G$1" pin="7"/>
-<wire x1="-17.78" y1="0" x2="-17.78" y2="2.54" width="0.1524" layer="91"/>
-<wire x1="-17.78" y1="2.54" x2="-20.32" y2="2.54" width="0.1524" layer="91"/>
-<junction x="-17.78" y="0"/>
-<pinref part="S1" gate="G$1" pin="8"/>
-<wire x1="-17.78" y1="2.54" x2="-17.78" y2="5.08" width="0.1524" layer="91"/>
-<wire x1="-17.78" y1="5.08" x2="-20.32" y2="5.08" width="0.1524" layer="91"/>
-<junction x="-17.78" y="2.54"/>
-<wire x1="-17.78" y1="5.08" x2="-15.24" y2="5.08" width="0.1524" layer="91"/>
-<junction x="-17.78" y="5.08"/>
-<label x="-15.24" y="5.08" size="1.778" layer="95"/>
-</segment>
-<segment>
 <pinref part="LED_RING" gate="-1" pin="1"/>
 <wire x1="-152.4" y1="-38.1" x2="-154.94" y2="-38.1" width="0.1524" layer="91"/>
 <label x="-157.48" y="-38.1" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="FAN" gate="-3" pin="S"/>
+<wire x1="-33.02" y1="-35.56" x2="-35.56" y2="-35.56" width="0.1524" layer="91"/>
+<label x="-40.64" y="-35.56" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="GND" class="0">
@@ -9330,14 +9419,19 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <label x="-43.18" y="17.78" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="R1" gate="A" pin="2"/>
-<wire x1="-149.86" y1="2.54" x2="-152.4" y2="2.54" width="0.1524" layer="91"/>
-<label x="-154.94" y="2.54" size="1.778" layer="95"/>
-</segment>
-<segment>
 <pinref part="LED_RING" gate="-2" pin="1"/>
 <wire x1="-154.94" y1="-40.64" x2="-152.4" y2="-40.64" width="0.1524" layer="91"/>
 <label x="-157.48" y="-40.64" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="R1" gate="A" pin="1"/>
+<wire x1="-149.86" y1="27.94" x2="-152.4" y2="27.94" width="0.1524" layer="91"/>
+<label x="-154.94" y="27.94" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="FAN" gate="-4" pin="S"/>
+<wire x1="-33.02" y1="-38.1" x2="-35.56" y2="-38.1" width="0.1524" layer="91"/>
+<label x="-40.64" y="-38.1" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="L0M1" class="0">
@@ -9669,9 +9763,9 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <label x="-144.78" y="83.82" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="R1" gate="A" pin="1"/>
-<wire x1="-149.86" y1="27.94" x2="-152.4" y2="27.94" width="0.1524" layer="91"/>
-<label x="-154.94" y="27.94" size="1.778" layer="95"/>
+<pinref part="R1" gate="A" pin="2"/>
+<wire x1="-149.86" y1="2.54" x2="-152.4" y2="2.54" width="0.1524" layer="91"/>
+<label x="-154.94" y="2.54" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="12V_PRE" class="0">
@@ -9783,6 +9877,23 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <wire x1="-33.02" y1="-15.24" x2="-35.56" y2="-15.24" width="0.1524" layer="91"/>
 <label x="-38.1" y="-15.24" size="1.778" layer="95"/>
 </segment>
+<segment>
+<pinref part="S1" gate="G$1" pin="8"/>
+<wire x1="-20.32" y1="5.08" x2="-17.78" y2="5.08" width="0.1524" layer="91"/>
+<pinref part="S1" gate="G$1" pin="7"/>
+<wire x1="-20.32" y1="2.54" x2="-17.78" y2="2.54" width="0.1524" layer="91"/>
+<wire x1="-17.78" y1="5.08" x2="-17.78" y2="2.54" width="0.1524" layer="91"/>
+<pinref part="S1" gate="G$1" pin="6"/>
+<wire x1="-20.32" y1="0" x2="-17.78" y2="0" width="0.1524" layer="91"/>
+<junction x="-17.78" y="2.54"/>
+<pinref part="S1" gate="G$1" pin="5"/>
+<wire x1="-20.32" y1="-2.54" x2="-17.78" y2="-2.54" width="0.1524" layer="91"/>
+<wire x1="-17.78" y1="0" x2="-17.78" y2="-2.54" width="0.1524" layer="91"/>
+<junction x="-17.78" y="0"/>
+<wire x1="-17.78" y1="2.54" x2="-17.78" y2="0" width="0.1524" layer="91"/>
+<wire x1="-17.78" y1="0" x2="-15.24" y2="0" width="0.1524" layer="91"/>
+<label x="-15.24" y="0" size="1.778" layer="95"/>
+</segment>
 </net>
 <net name="PWRSIG" class="0">
 <segment>
@@ -9801,18 +9912,36 @@ Number of pins: &lt;b&gt;2&lt;/b&gt;&lt;b&gt;&lt;P&gt;
 <label x="-58.42" y="45.72" size="1.778" layer="95"/>
 </segment>
 </net>
+<net name="FAN_PWM" class="0">
+<segment>
+<pinref part="FAN" gate="-1" pin="S"/>
+<wire x1="-33.02" y1="-30.48" x2="-35.56" y2="-30.48" width="0.1524" layer="91"/>
+<label x="-48.26" y="-30.48" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="RPI5" gate="G$1" pin="32"/>
+<wire x1="-20.32" y1="27.94" x2="-17.78" y2="27.94" width="0.1524" layer="91"/>
+<label x="-17.78" y="27.94" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="FAN_RPM" class="0">
+<segment>
+<pinref part="FAN" gate="-2" pin="S"/>
+<wire x1="-33.02" y1="-33.02" x2="-35.56" y2="-33.02" width="0.1524" layer="91"/>
+<label x="-48.26" y="-33.02" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="RPI5" gate="G$1" pin="38"/>
+<wire x1="-20.32" y1="20.32" x2="-17.78" y2="20.32" width="0.1524" layer="91"/>
+<label x="-17.78" y="20.32" size="1.778" layer="95"/>
+</segment>
+</net>
 </nets>
 </sheet>
 </sheets>
 <errors>
 <approved hash="104,1,-172.72,88.9,BATTERY,+,12V_PRE,,,"/>
 <approved hash="104,1,-172.72,83.82,BATTERY,-,GND,,,"/>
-<approved hash="104,1,-147.32,88.9,BUCK_IN,+,12V,,,"/>
-<approved hash="104,1,-147.32,83.82,BUCK_IN,-,GND,,,"/>
-<approved hash="104,1,-129.54,88.9,BUCK_OUT,+,5V,,,"/>
-<approved hash="104,1,-129.54,83.82,BUCK_OUT,-,GND,,,"/>
-<approved hash="104,1,-129.54,109.22,POWER_SWITCH,+,12V_PRE,,,"/>
-<approved hash="104,1,-129.54,104.14,POWER_SWITCH,-,12V,,,"/>
 </errors>
 </schematic>
 </drawing>


### PR DESCRIPTION
- Use 3.3V logic instead of 5v logic for dipswitches
- Swap 12V and GND on the Voltage divider based on the datasheet and calculations (We want R1 to be 4k and R2 to be 1k).
- Add in Noctua 5V fan connections after verifying pinout