### PR TITLE
updates to sit and moveToPosAtSpeed

### DIFF
--- a/mk2/code/real_time/teensy_code/lib/HexapodController/src/axis.cpp
+++ b/mk2/code/real_time/teensy_code/lib/HexapodController/src/axis.cpp
@@ -50,8 +50,14 @@ uint8_t Axis::moveToPosAtSpeed(double pos, double target_speed) { //Must call ru
         speed = _max_speed;
         retval = 1; // move speed capped
     }
-    _move_time = (fabs(getCurrentPos() - pos) / speed) * 1000;
+    if ((getCurrentPos() - pos) == 0) {
+        _move_time = 1;
+    }
+    else {
+        _move_time = (fabs(getCurrentPos() - pos) / speed) * 1000;
+    }
     _start_rads = getCurrentPos();
+    Serial.printf("start pos is: %f, target pos is %f\n", _start_rads, pos);
     _end_rads = pos;
     _move_progress = 0;
     _move_start_time = millis();

--- a/mk2/code/real_time/teensy_code/lib/HexapodController/src/hexapod.cpp
+++ b/mk2/code/real_time/teensy_code/lib/HexapodController/src/hexapod.cpp
@@ -16,6 +16,11 @@ Hexapod::Hexapod() {
 }
 
 void Hexapod::startUp() {
+
+	#if DEBUG
+	return; 
+	#endif
+
 	uint32_t start_time = millis();
 	while(1) {
 		if (millis() >= (start_time + 5000)) {


### PR DESCRIPTION
fix bug in moveToPosAtSpeed which caused motors not to move if already at target position. Needed to change because sit writes some motors to 0 on startup. Without initial movement at start these motors are not idle and could be freely moved by hand

also use the DEBUG flag from user_config.hpp to disable automated sit on startup functionality. During debug this feature is distracting and also not needed.