### PR TITLE
Add Display Functionality

### DIFF
--- a/mk2/code/non_real_time/container/Dockerfile
+++ b/mk2/code/non_real_time/container/Dockerfile
@@ -8,7 +8,7 @@ apt-get upgrade -y
 
 # Setup python and system dependencies
 ADD setup /app/setup
-RUN bash -c 'apt-get install --no-install-recommends --fix-missing -y $(cat /app/setup/system-requirements.txt)'
+RUN bash -c 'apt-get install -y $(cat /app/setup/system-requirements.txt)'
 RUN apt full-upgrade -y
 RUN pip3 install --no-cache-dir -r /app/setup/python-requirements.txt
 

--- a/mk2/code/non_real_time/container/docker-compose-dev.yml
+++ b/mk2/code/non_real_time/container/docker-compose-dev.yml
@@ -8,7 +8,7 @@ services:
       - /dev/ttyAMA0:/dev/ttyAMA0:rw
       - /dev/input/:/dev/input/  # Pass all input devices
       - /tmp/.X11-unix:/tmp/.X11-unix  # Share XWayland socket
-      - /run/user/1002:/run/user/1002  # Share Mutter XWayland auth
+      - /run/user/1002/.mutter-Xwaylandauth.GL9S22:/root/.Xauthority  # Share Mutter XWayland auth
     environment:
       - DISPLAY=:0
       - XAUTHORITY=/root/.Xauthority  # Set correct X auth file inside container

--- a/mk2/code/non_real_time/container/docker-compose-dev.yml
+++ b/mk2/code/non_real_time/container/docker-compose-dev.yml
@@ -6,14 +6,14 @@ services:
       - ./src:/app/src
       - /var/run/dbus/:/var/run/dbus/:z
       - /dev/ttyAMA0:/dev/ttyAMA0:rw
-      - /dev/input/:/dev/input/  # Pass all input devices
-      - /tmp/.X11-unix:/tmp/.X11-unix  # Share XWayland socket
-      - /run/user/1002/.mutter-Xwaylandauth.GL9S22:/root/.Xauthority  # Share Mutter XWayland auth
+      - /dev/input/:/dev/input/
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${XAUTH_FILE}:/root/.Xauthority
     environment:
       - DISPLAY=:0
-      - XAUTHORITY=/root/.Xauthority  # Set correct X auth file inside container
-      - QT_QPA_PLATFORM=xcb  # Force Qt to use XWayland
+      - XAUTHORITY=/root/.Xauthority
+      - QT_QPA_PLATFORM=xcb
     devices:
-      - /dev/dri:/dev/dri  # Necessary for graphical applications
+      - /dev/dri:/dev/dri
     privileged: true
     entrypoint: ["bash", "/app/src/idle_entry_point.sh"]

--- a/mk2/code/non_real_time/container/docker-compose-dev.yml
+++ b/mk2/code/non_real_time/container/docker-compose-dev.yml
@@ -8,7 +8,7 @@ services:
       - /dev/ttyAMA0:/dev/ttyAMA0:rw
       - /dev/input/:/dev/input/  # Pass all input devices
       - /tmp/.X11-unix:/tmp/.X11-unix  # Share XWayland socket
-      - /run/user/1002/.mutter-Xwaylandauth.WK4W22:/root/.Xauthority  # Share Mutter XWayland auth
+      - /run/user/1002:/run/user/1002  # Share Mutter XWayland auth
     environment:
       - DISPLAY=:0
       - XAUTHORITY=/root/.Xauthority  # Set correct X auth file inside container

--- a/mk2/code/non_real_time/container/docker-compose-dev.yml
+++ b/mk2/code/non_real_time/container/docker-compose-dev.yml
@@ -3,9 +3,17 @@ services:
     image: hexapod:latest
     container_name: hexapod_latest
     volumes:
-     - ./src:/app/src
-     - /var/run/dbus/:/var/run/dbus/:z
-     - /dev/ttyAMA0:/dev/ttyAMA0:rw
-     - /dev/input/:/dev/input/
+      - ./src:/app/src
+      - /var/run/dbus/:/var/run/dbus/:z
+      - /dev/ttyAMA0:/dev/ttyAMA0:rw
+      - /dev/input/:/dev/input/  # Pass all input devices
+      - /tmp/.X11-unix:/tmp/.X11-unix  # Share XWayland socket
+      - /run/user/1002/.mutter-Xwaylandauth.WK4W22:/root/.Xauthority  # Share Mutter XWayland auth
+    environment:
+      - DISPLAY=:0
+      - XAUTHORITY=/root/.Xauthority  # Set correct X auth file inside container
+      - QT_QPA_PLATFORM=xcb  # Force Qt to use XWayland
+    devices:
+      - /dev/dri:/dev/dri  # Necessary for graphical applications
     privileged: true
     entrypoint: ["bash", "/app/src/idle_entry_point.sh"]

--- a/mk2/code/non_real_time/container/init_dev.sh
+++ b/mk2/code/non_real_time/container/init_dev.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+export XAUTH_FILE=$(ls /run/user/1002/.mutter-Xwaylandauth.* | head -n 1)
 docker compose -f docker-compose-dev.yml up -d

--- a/mk2/code/non_real_time/container/setup/python-requirements.txt
+++ b/mk2/code/non_real_time/container/setup/python-requirements.txt
@@ -2,3 +2,5 @@ pygame
 pyserial
 adafruit-circuitpython-neopixel-spi
 adafruit-blinka
+pyqt5
+python_qt_binding

--- a/mk2/code/non_real_time/container/setup/system-requirements.txt
+++ b/mk2/code/non_real_time/container/setup/system-requirements.txt
@@ -19,3 +19,11 @@ ros-iron-teleop-twist-keyboard
 ros-iron-teleop-twist-joy
 ros-iron-joy-linux
 ros-iron-rqt*
+libwayland-client0
+libwayland-server0
+wayland-protocols
+weston
+xwayland
+qt5-wayland
+libxcb-xinerama0
+x11-apps

--- a/mk2/code/non_real_time/container/setup/system-requirements.txt
+++ b/mk2/code/non_real_time/container/setup/system-requirements.txt
@@ -19,11 +19,12 @@ ros-iron-teleop-twist-keyboard
 ros-iron-teleop-twist-joy
 ros-iron-joy-linux
 ros-iron-rqt*
+ros-iron-sensor-msgs
 libwayland-client0
 libwayland-server0
 wayland-protocols
 weston
 xwayland
-qt5-wayland
+qtwayland5
 libxcb-xinerama0
 x11-apps

--- a/mk2/code/non_real_time/container/src/idle_entry_point.sh
+++ b/mk2/code/non_real_time/container/src/idle_entry_point.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
 ##########################################################################################
-# This entrypoint can be specified to just have the container running indefinetely in idle
+# This entrypoint can be specified to just have the container running indefinitely in idle
 ##########################################################################################
 
+# Find the mutter-Xwaylandauth file and symlink it to the correct location
+AUTH_FILE=$(find /run/user/1002/ -name 'mutter-Xwaylandauth*' | head -n 1)
+
+if [ -n "$AUTH_FILE" ]; then
+  ln -sf "$AUTH_FILE" /root/.Xauthority
+else
+  echo "Xwayland auth file not found!"
+  exit 1  # Exit if the file is not found
+fi
+
+# Keep the container running indefinitely in idle
 while :
-do 
+do
     sleep 1
 done

--- a/mk2/code/non_real_time/container/src/idle_entry_point.sh
+++ b/mk2/code/non_real_time/container/src/idle_entry_point.sh
@@ -4,17 +4,6 @@
 # This entrypoint can be specified to just have the container running indefinitely in idle
 ##########################################################################################
 
-# Find the mutter-Xwaylandauth file and symlink it to the correct location
-AUTH_FILE=$(find /run/user/1002/ -name 'mutter-Xwaylandauth*' | head -n 1)
-
-if [ -n "$AUTH_FILE" ]; then
-  ln -sf "$AUTH_FILE" /root/.Xauthority
-else
-  echo "Xwayland auth file not found!"
-  exit 1  # Exit if the file is not found
-fi
-
-# Keep the container running indefinitely in idle
 while :
 do
     sleep 1

--- a/mk2/code/non_real_time/container/src/ros2_ws/src/gait/gait/teensy_gait.py
+++ b/mk2/code/non_real_time/container/src/ros2_ws/src/gait/gait/teensy_gait.py
@@ -54,6 +54,8 @@ class TeensyGait(Node):
             else:
                 self.resetPos()
             self.publisher.publish(self.prepCommand(self.joy_cmd))
+            print(f"=================================")
+            print(f"Sending message {self.prepCommand(self.joy_cmd)}")
             self.last_joy_cmd = copy.deepcopy(self.joy_cmd)
             self.joy_cmd = {}
             self.last_command_time = current_time

--- a/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/hexapod_manager/display.py
+++ b/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/hexapod_manager/display.py
@@ -1,0 +1,88 @@
+import pygame
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Joy
+
+class HexapodTouchscreen(Node):
+    def __init__(self):
+        super().__init__('hexapod_touchscreen')
+        self.publisher = self.create_publisher(Joy, '/joy', 10)
+        
+        # Initialize Pygame
+        pygame.init()
+        self.screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)  # Fullscreen mode
+        pygame.display.set_caption("Hexapod Control")
+
+        # Define button properties
+        self.button_color = (0, 128, 255)
+        self.font = pygame.font.Font(None, 72)  # Larger font size for title
+        self.button_font = pygame.font.Font(None, 48)  # Larger font size for buttons
+        self.scroll_font = pygame.font.Font(None, 36)  # Smaller font size for scrolling text
+        
+        # Define button positions and sizes
+        self.mode_button_rect = pygame.Rect(100, 200, 240, 100)  # Larger "mode" button
+        self.color_button_rect = pygame.Rect(400, 200, 240, 100)  # Larger "color" button
+        
+        self.scroll_text = "Manufactured Motion"
+        self.scroll_pos = self.screen.get_width()  # Start position for scrolling text
+        self.running = True
+
+    def draw_buttons(self):
+        # Draw the "mode" button
+        pygame.draw.rect(self.screen, self.button_color, self.mode_button_rect)
+        mode_text = self.button_font.render("Mode", True, (255, 255, 255))
+        self.screen.blit(mode_text, (self.mode_button_rect.centerx - mode_text.get_width() // 2,
+                                     self.mode_button_rect.centery - mode_text.get_height() // 2))  # Center text
+
+        # Draw the "color" button
+        pygame.draw.rect(self.screen, self.button_color, self.color_button_rect)
+        color_text = self.button_font.render("Color", True, (255, 255, 255))
+        self.screen.blit(color_text, (self.color_button_rect.centerx - color_text.get_width() // 2,
+                                      self.color_button_rect.centery - color_text.get_height() // 2))  # Center text
+
+        # Draw the title
+        title_text = self.font.render("Hexapod Mark II", True, (255, 255, 255))
+        self.screen.blit(title_text, (self.screen.get_width() // 2 - title_text.get_width() // 2, 50))  # Center title
+
+        # Draw scrolling text at the bottom
+        scroll_text_surface = self.scroll_font.render(self.scroll_text, True, (255, 255, 255))
+        self.screen.blit(scroll_text_surface, (self.scroll_pos, self.screen.get_height() - 50))  # Position at the bottom
+
+    def send_joy_message(self, button_index):
+        msg = Joy()
+        msg.buttons = [0] * 12  # Initialize all buttons to 0
+        msg.buttons[button_index] = 1  # Press the specified button
+        self.publisher.publish(msg)
+        self.get_logger().info(f"Published to /joy topic with button {button_index} pressed")
+
+    def run(self):
+        while self.running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.running = False
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if self.mode_button_rect.collidepoint(event.pos):
+                        self.send_joy_message(10)  # Send joy 10 for "mode"
+                    elif self.color_button_rect.collidepoint(event.pos):
+                        self.send_joy_message(11)  # Send joy 11 for "color"
+
+            # Update scrolling text position
+            self.scroll_pos -= 2  # Scroll speed
+            if self.scroll_pos < -self.scroll_font.size(self.scroll_text)[0]:
+                self.scroll_pos = self.screen.get_width()  # Reset position to start
+
+            # Refresh screen
+            self.screen.fill((0, 0, 0))  # Black background
+            self.draw_buttons()
+            pygame.display.flip()
+
+        pygame.quit()
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = HexapodTouchscreen()
+    node.run()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/hexapod_manager/display.py
+++ b/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/hexapod_manager/display.py
@@ -8,50 +8,46 @@ class HexapodTouchscreen(Node):
         super().__init__('hexapod_touchscreen')
         self.publisher = self.create_publisher(Joy, '/joy', 10)
         
-        # Initialize Pygame
         pygame.init()
-        self.screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)  # Fullscreen mode
+        self.screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
         pygame.display.set_caption("Hexapod Control")
 
-        # Define button properties
         self.button_color = (0, 128, 255)
-        self.font = pygame.font.Font(None, 72)  # Larger font size for title
-        self.button_font = pygame.font.Font(None, 48)  # Larger font size for buttons
-        self.scroll_font = pygame.font.Font(None, 36)  # Smaller font size for scrolling text
+        self.font = pygame.font.Font(None, 72)
+        self.button_font = pygame.font.Font(None, 48)
+        self.scroll_font = pygame.font.Font(None, 36)
         
-        # Define button positions and sizes
-        self.mode_button_rect = pygame.Rect(100, 200, 240, 100)  # Larger "mode" button
-        self.color_button_rect = pygame.Rect(400, 200, 240, 100)  # Larger "color" button
+        screen_width, screen_height = self.screen.get_size()
+        button_width, button_height = 240, 100
+        
+        self.mode_button_rect = pygame.Rect((screen_width // 2 - button_width - 20, screen_height // 2 - button_height // 2), (button_width, button_height))
+        self.color_button_rect = pygame.Rect((screen_width // 2 + 20, screen_height // 2 - button_height // 2), (button_width, button_height))
         
         self.scroll_text = "Manufactured Motion"
-        self.scroll_pos = self.screen.get_width()  # Start position for scrolling text
+        self.scroll_pos = self.screen.get_width()
         self.running = True
 
     def draw_buttons(self):
-        # Draw the "mode" button
         pygame.draw.rect(self.screen, self.button_color, self.mode_button_rect)
         mode_text = self.button_font.render("Mode", True, (255, 255, 255))
         self.screen.blit(mode_text, (self.mode_button_rect.centerx - mode_text.get_width() // 2,
-                                     self.mode_button_rect.centery - mode_text.get_height() // 2))  # Center text
+                                     self.mode_button_rect.centery - mode_text.get_height() // 2))
 
-        # Draw the "color" button
         pygame.draw.rect(self.screen, self.button_color, self.color_button_rect)
         color_text = self.button_font.render("Color", True, (255, 255, 255))
         self.screen.blit(color_text, (self.color_button_rect.centerx - color_text.get_width() // 2,
-                                      self.color_button_rect.centery - color_text.get_height() // 2))  # Center text
+                                      self.color_button_rect.centery - color_text.get_height() // 2))
 
-        # Draw the title
         title_text = self.font.render("Hexapod Mark II", True, (255, 255, 255))
-        self.screen.blit(title_text, (self.screen.get_width() // 2 - title_text.get_width() // 2, 50))  # Center title
+        self.screen.blit(title_text, (self.screen.get_width() // 2 - title_text.get_width() // 2, 50))
 
-        # Draw scrolling text at the bottom
         scroll_text_surface = self.scroll_font.render(self.scroll_text, True, (255, 255, 255))
-        self.screen.blit(scroll_text_surface, (self.scroll_pos, self.screen.get_height() - 50))  # Position at the bottom
+        self.screen.blit(scroll_text_surface, (self.scroll_pos, self.screen.get_height() - 50))
 
     def send_joy_message(self, button_index):
         msg = Joy()
-        msg.buttons = [0] * 12  # Initialize all buttons to 0
-        msg.buttons[button_index] = 1  # Press the specified button
+        msg.buttons = [0] * 12
+        msg.buttons[button_index] = 1
         self.publisher.publish(msg)
         self.get_logger().info(f"Published to /joy topic with button {button_index} pressed")
 
@@ -62,27 +58,27 @@ class HexapodTouchscreen(Node):
                     self.running = False
                 if event.type == pygame.MOUSEBUTTONDOWN:
                     if self.mode_button_rect.collidepoint(event.pos):
-                        self.send_joy_message(10)  # Send joy 10 for "mode"
+                        self.send_joy_message(10)
                     elif self.color_button_rect.collidepoint(event.pos):
-                        self.send_joy_message(11)  # Send joy 11 for "color"
+                        self.send_joy_message(11)
 
-            # Update scrolling text position
-            self.scroll_pos -= 2  # Scroll speed
+            self.scroll_pos -= 2
             if self.scroll_pos < -self.scroll_font.size(self.scroll_text)[0]:
-                self.scroll_pos = self.screen.get_width()  # Reset position to start
+                self.scroll_pos = self.screen.get_width()
 
-            # Refresh screen
-            self.screen.fill((0, 0, 0))  # Black background
+            self.screen.fill((0, 0, 0))
             self.draw_buttons()
             pygame.display.flip()
 
         pygame.quit()
+
 
 def main(args=None):
     rclpy.init(args=args)
     node = HexapodTouchscreen()
     node.run()
     rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/setup.py
+++ b/mk2/code/non_real_time/container/src/ros2_ws/src/hexapod_manager/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'led_controller = hexapod_manager.led_controller:main',
+            'display = hexapod_manager.display:main',
         ],
     },
 )


### PR DESCRIPTION
Add in functionality to control the display from the docker container and Ros2.

`ros2 run hexapod_manager display` turns on a default display with "Hexapod MKII" at the top, and buttons to change the LED color and pattern.

`rqt_graph` is a built in function to make a graph of the different nodes.